### PR TITLE
Chore/create react class

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var React = require('react');
+var createReactClass = require('create-react-class');
 
-module.exports = React.createClass({
+module.exports = createReactClass({
 	initialize: function(node) {
 		if (node === null) return;
 		var app = this.props.src.embed(node, this.props.flags);

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "type": "git",
     "url": "git+https://github.com/evancz/react-elm-components.git"
   },
+  "dependencies": {
+    "create-react-class": "^15.5.3"
+  },
   "peerDependencies": {
     "react": ">=0.14.0"
   },


### PR DESCRIPTION
hello, this PR introduces `createReactClass` which is to be used instead of now deprecated `React.createClass`.

didn't want to use es2015 class because some build step is required then, and simply exporting class wouldn't be enough, imo.

no more deprecation warning.
closes #10