### PR TITLE
Extending React.Component rather than using createClass

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,20 +1,26 @@
 var React = require('react');
 
-module.exports = React.createClass({
-	initialize: function(node) {
-		if (node === null) return;
-		var app = this.props.src.embed(node, this.props.flags);
+module.exports = class extends React.Component {
+  constructor(props) {
+    super(props);
 
-		if (typeof this.props.ports !== 'undefined') {
-			this.props.ports(app.ports);
-		}
-	},
+    this.initialize = this.initialize.bind(this);
+  }
 
-	shouldComponentUpdate: function(prevProps) {
-		return false;
-	},
+  shouldComponentUpdate() {
+    return false;
+  }
 
-	render: function () {
-		return React.createElement('div', { ref: this.initialize });
-	}
-});
+  initialize(node) {
+    if (node === null) return;
+    var app = this.props.src.embed(node, this.props.flags);
+
+    if (typeof this.props.ports !== 'undefined') {
+      this.props.ports(app.ports);
+    }
+  }
+
+  render() {
+    return React.createElement('div', { ref: this.initialize });
+  }
+}


### PR DESCRIPTION
With React 16 coming soon and removing `createClass` from the main React package I just re-implemented the component extending `React.Component`.

I saw PR #11 trying to solve the same issue by adding `create-react-class` as a dependency. I reckon most people are running node v4+ so probably no need for adding that dependency.

I've simply re-implemented it "as is" without questioning the logic but if we get rid of the life-cycle method `shouldComponentUpdate` this could simply be a pure function.
