### PR TITLE
Problem: Broken link to 'embedding Elm in HTML'

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -91,4 +91,4 @@ var app = Elm.Todo.embed(node, flags);
 setupPorts(app.ports)
 ```
 
-So if you are interested in embedding Elm in something else, do the same trick! You can get more complete docs on embedding Elm in HTML [here](http://guide.elm-lang.org/interop/html.html) and JavaScript interop [here](http://guide.elm-lang.org/interop/javascript.html). Let the community know if you make something!
+So if you are interested in embedding Elm in something else, do the same trick! You can get more complete docs on embedding Elm in HTML and JavaScript interop [here](http://guide.elm-lang.org/interop/javascript.html). Let the community know if you make something!


### PR DESCRIPTION
Seems like that page either never existed, or was folded into the JavaScript interop page.

Solution: Removed broken link.

(Fortunately the sentence is still grammatical without it. :)