### PR TITLE
Update readme.md to link to correct interop page

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -91,4 +91,4 @@ var app = Elm.Todo.embed(node, flags);
 setupPorts(app.ports)
 ```
 
-So if you are interested in embedding Elm in something else, do the same trick! You can get more complete docs on embedding Elm in HTML [here](http://guide.elm-lang.org/interop/html.html) and JavaScript interop [here](http://guide.elm-lang.org/interop/javascript.html). Let the community know if you make something!
+So if you are interested in embedding Elm in something else, do the same trick! You can get more complete docs on embedding Elm in HTML and JavaScript [here](https://guide.elm-lang.org/interop/). Let the community know if you make something!


### PR DESCRIPTION
References to http://guide.elm-lang.org/interop/html.html http://guide.elm-lang.org/interop/javascript.html no longer exist.

Updated readme to link to http://guide.elm-lang.org/interop/