### PR TITLE
Upgrade to Elm 0.19

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var createReactClass = require('create-react-class');
 module.exports = createReactClass({
 	initialize: function(node) {
 		if (node === null) return;
-		var app = this.props.src.embed(node, this.props.flags);
+		var app = this.props.src.init({node: node, flags: this.props.flags});
 
 		if (typeof this.props.ports !== 'undefined') {
 			this.props.ports(app.ports);


### PR DESCRIPTION
I encountered an error trying to embed Elm `0.19` in a React app using this package. Changing `embed` to `init` seems to address the change.

Not sure if this project aims to target Elm `0.19`. I know it would take some more changes, especially to the example project, but I figured I would call attention to the issue with this PR to get the ball rolling.

[Commit](https://github.com/akselw/react-elm-components/pull/7/commits/73b87f26c1530d46085ee331b04a96ef10897f84) and [issue](https://github.com/akselw/react-elm-components/issues/6) from upgrade to `0.18` for reference.