### PR TITLE
Update the Javascript Interop Link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -91,7 +91,7 @@ var app = Elm.Todo.embed(node, flags);
 setupPorts(app.ports)
 ```
 
-So if you are interested in embedding Elm in something else, do the same trick! You can get more complete docs on embedding Elm in HTML [here](http://guide.elm-lang.org/interop/html.html) and JavaScript interop [here](http://guide.elm-lang.org/interop/javascript.html). Let the community know if you make something!
+So if you are interested in embedding Elm in something else, do the same trick! You can get more complete docs on embedding Elm in HTML [here](http://guide.elm-lang.org/interop/html.html) and JavaScript interop [here](https://guide.elm-lang.org/interop/). Let the community know if you make something!
 
 
 ---


### PR DESCRIPTION
The original link was incorrect. I've updated it with the latest link. Additionally, the link about embedding Elm in HTML is also broken, but I can't find what it was originally referring to.