### PR TITLE
Create TypeScript index.d.ts definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,25 @@
+declare module "react-elm-components" {
+  import React from "react";
+
+  export type ElmApp<Flags, Ports> =
+    | { init: (options: { flags: Flags }) => { ports: Ports } }
+    | { embed: (node: any, flags: Flags) => { ports: Ports } };
+
+  export type Ports<T extends ElmApp<any, any>> = T extends ElmApp<any, infer P>
+    ? P
+    : never;
+
+  export type Flags<T extends ElmApp<any, any>> = T extends ElmApp<infer F, any>
+    ? F
+    : never;
+
+  export interface Props<Flags, Ports> {
+    src: ElmApp<Flags, Ports>;
+    flags: Flags;
+    ports?: (ports: Ports) => void;
+  }
+
+  export default class Elm<Flags, Ports> extends React.Component<
+    Props<Flags, Ports>
+  > {}
+}


### PR DESCRIPTION
Adds typescript support for the component which embeds Elm code in
React. Also provides helper types for extracting the Ports and Flags
used by an Elm program.

These type declarations are useful in contexts where the TypeScript
type declaration of the underlying Elm program is either hand-written,
or generated by a tool such as `elm-typescript-interop`.

If the Culture Amp team isn't interested in taking responsibility for typescript files then I'm happy to create a `@types/react-elm-components` package under the `DefinitelyTyped` repo instead :)